### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Scryfall MCP Server
 
+[![smithery badge](https://smithery.ai/badge/@cryppadotta/scryfall-mcp)](https://smithery.ai/server/@cryppadotta/scryfall-mcp)
+
 A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for interacting with the [Scryfall](https://scryfall.com/docs/api) API. It provides tools to look up Magic: The Gathering card details, card rulings, and price information.
 
 ## Features
@@ -37,6 +39,14 @@ npx -y @modelcontextprotocol/server-scryfall
 
 # SSE mode
 npx -y @modelcontextprotocol/server-scryfall --sse
+```
+
+### Installing via Smithery
+
+To install Scryfall MCP Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@cryppadotta/scryfall-mcp):
+
+```bash
+npx -y @smithery/cli install @cryppadotta/scryfall-mcp --client claude
 ```
 
 ### Connecting to the Server

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,13 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required: []
+    properties: {}
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command:'node', args:['/app/dist/index.js']})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over WebSockets so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@cryppadotta/scryfall-mcp?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂