### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ A [Model Context Protocol (MCP)](https://modelcontextprotocol.io/) server for in
 
 ![Scryfall MCP Server](img/sorcerer.jpg)
 
+<a href="https://glama.ai/mcp/servers/jdaj6hj69s"><img width="380" height="200" src="https://glama.ai/mcp/servers/jdaj6hj69s/badge" alt="Scryfall Server MCP server" /></a>
+
 ## Features
 
 - **search_cards**  


### PR DESCRIPTION
This PR adds a badge for the [Scryfall MCP Server](https://glama.ai/mcp/servers/jdaj6hj69s) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/jdaj6hj69s"><img width="380" height="200" src="https://glama.ai/mcp/servers/jdaj6hj69s/badge" alt="Scryfall Server MCP server" /></a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.